### PR TITLE
fix: modify project doctype to change actual_start_date fieldtype from data to date

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -234,7 +234,7 @@
   },
   {
    "fieldname": "actual_start_date",
-   "fieldtype": "Data",
+   "fieldtype": "Date",
    "label": "Actual Start Date (via Time Sheet)",
    "read_only": 1
   },


### PR DESCRIPTION
I have noticed that project's “actual start date” is not shown with the same format that other start/end dates in some reports. See image below.

![project_report](https://user-images.githubusercontent.com/93864988/169659387-bcbf5777-a173-4a19-9ff2-3f4b6d3da7a4.png)

This is because the field actual_start_date is defined as "Data" instead of "Date" in the doctype. I have looked through the code and the fields actual_start_date and actual_end_date are managed in the same way, but actual_end_date is defined as "Date" while actual_start_date is defined as "Data". I think this could be a typo.